### PR TITLE
区块管理删除的bug

### DIFF
--- a/application/admin/controller/BlockController.php
+++ b/application/admin/controller/BlockController.php
@@ -111,6 +111,10 @@ class BlockController extends AdminController
         $map = ['block_id' => $id];
         $AccessMenuBlockModel->where($map)->delete();
 
+        //删除usergroup-menu关联表中已经删除的区块信息
+        $AccessUserGroupBlockModel = new AccessUserGroupBlockModel;
+        $AccessUserGroupBlockModel->where($map)->delete();
+        
         if (false === $BlockModel) {
             return $this->error('删除失败:区块不存在' . $BlockModel->getError());
         }


### PR DESCRIPTION
删除区块时，删除关联的权限菜单用户组表
